### PR TITLE
モデル・テーブルの作成

### DIFF
--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -1,0 +1,2 @@
+class Movie < ApplicationRecord
+end

--- a/app/models/text.rb
+++ b/app/models/text.rb
@@ -1,0 +1,2 @@
+class Text < ApplicationRecord
+end

--- a/db/migrate/20220202131510_create_texts.rb
+++ b/db/migrate/20220202131510_create_texts.rb
@@ -1,0 +1,11 @@
+class CreateTexts < ActiveRecord::Migration[6.1]
+  def change
+    create_table :texts do |t|
+      t.integer :genre, default: 0, null: false
+      t.string :title, null: false
+      t.text :content, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220202132253_create_movies.rb
+++ b/db/migrate/20220202132253_create_movies.rb
@@ -1,0 +1,11 @@
+class CreateMovies < ActiveRecord::Migration[6.1]
+  def change
+    create_table :movies do |t|
+      t.integer :genre, default: 0, null: false
+      t.string :title, null: false
+      t.text :content, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220203114114_remove_content_from_movies.rb
+++ b/db/migrate/20220203114114_remove_content_from_movies.rb
@@ -1,0 +1,5 @@
+class RemoveContentFromMovies < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :movies, :content, :text
+  end
+end

--- a/db/migrate/20220203114330_add_url_to_movies.rb
+++ b/db/migrate/20220203114330_add_url_to_movies.rb
@@ -1,0 +1,5 @@
+class AddUrlToMovies < ActiveRecord::Migration[6.1]
+  def change
+    add_column :movies, :url, :string
+  end
+end

--- a/db/migrate/20220203115344_change_clumns_notnull_add_movies.rb
+++ b/db/migrate/20220203115344_change_clumns_notnull_add_movies.rb
@@ -1,0 +1,5 @@
+class ChangeClumnsNotnullAddMovies < ActiveRecord::Migration[6.1]
+  def change
+    change_column :movies, :url, :string, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_02_132253) do
+ActiveRecord::Schema.define(version: 2022_02_03_115344) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -18,9 +18,9 @@ ActiveRecord::Schema.define(version: 2022_02_02_132253) do
   create_table "movies", force: :cascade do |t|
     t.integer "genre", default: 0, null: false
     t.string "title", null: false
-    t.text "content", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "url", null: false
   end
 
   create_table "texts", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,25 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 0) do
+ActiveRecord::Schema.define(version: 2022_02_02_132253) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "movies", force: :cascade do |t|
+    t.integer "genre", default: 0, null: false
+    t.string "title", null: false
+    t.text "content", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "texts", force: :cascade do |t|
+    t.integer "genre", default: 0, null: false
+    t.string "title", null: false
+    t.text "content", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
 
 end


### PR DESCRIPTION
close #4 

## 実装内容
- `Text`モデルと`texts`テーブルを作成
  - カラムは「`genre`（integer型）」「`title`（string型）」「`content`（text型）」
  - `NOT NULL制約`の設定
  - `genre`のデフォルト値を`0`に設定
- `Movie`モデルと`movies`テーブルを作成
  - カラムは「`genre`（integer型）」「`title`（string型）」「`url`（string型）」
   - `NOT NULL制約`の設定
  - `genre`のデフォルト値を`0`に設定

## 確認内容
- ターミナルで`rails db`を実行し、`NOT NULL制約`が入っていることと、「`genre` カラムのデフォルト値が `0`になっていること」を確認

## チェックリスト

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認

