### PR TITLE
バリデーションを追加

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -58,3 +58,7 @@ Rails/OutputSafety:
   Exclude:
     - 'app/helpers/markdown_helper.rb'
 
+Rails/ReversibleMigration:
+  Exclude:
+    - 'db/migrate/20220203115344_change_clumns_notnull_add_movies.rb'
+

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -57,3 +57,4 @@ Rails/FilePath:
 Rails/OutputSafety:
   Exclude:
     - 'app/helpers/markdown_helper.rb'
+

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -1,2 +1,16 @@
 class Movie < ApplicationRecord
+  with_options presence: true do
+    validates :genre
+    validates :title
+    validates :url
+  end
+
+  enum genre: {
+    invisible: 0, # 非表示
+    basic: 1,
+    git: 2,
+    ruby: 3,
+    rails: 4,
+    php: 5
+  }
 end

--- a/app/models/text.rb
+++ b/app/models/text.rb
@@ -1,2 +1,16 @@
 class Text < ApplicationRecord
+  with_options presence: true do
+    validates :genre
+    validates :title
+    validates :content
+  end
+
+  enum genre: {
+    invisible: 0,
+    basic: 1,
+    git: 2,
+    ruby: 3,
+    rails: 4,
+    php: 5
+  }
 end


### PR DESCRIPTION
close #5 

## 実装内容
- 2種類のモデルの各カラムに空データが入らないようにするバリデーションを追加
　- `with_options` を使用
- `Text,` `Movie` モデルの `genre` カラムを「列挙型」にする
```
enum genre: {
    invisible: 0, # 非表示
    basic: 1,
    git: 2,
    ruby: 3,
    rails: 4,
    php: 5
  }
```

## 確認内容
ターミナルから以下のようなコマンドを実行し，「空データが入らないこと」「列挙型の設定ができていること」を確認
```
# sandbox モードで Rails コンソールを起動
rails c -s

# Railsコンソール起動後

Text.create!(title: "hoge", content: "")
#=> ActiveRecord::RecordInvalid: Validation failed: Content can't be blank

Movie.create!(title: "", url: "fuga")
#=> ActiveRecord::RecordInvalid: Validation failed: Title can't be blank

Text.genres
#=> {"invisible"=>0, "basic"=>1, "git"=>2, "ruby"=>3, "rails"=>4, "php"=>5}

Movie.genres
#=> {"invisible"=>0, "basic"=>1, "git"=>2, "ruby"=>3, "rails"=>4, "php"=>5}
```

## チェックリスト

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行

## 備考
robocop -a を実行した際に下記のファイルが自動修正できなかったため実行対象外に変更しました。
```
'db/migrate/20220203115344_change_clumns_notnull_add_movies.rb'
```