### PR TITLE
テキスト教材の読破済み機能

### DIFF
--- a/app/controllers/read_progresses_controller.rb
+++ b/app/controllers/read_progresses_controller.rb
@@ -1,0 +1,11 @@
+class ReadProgressesController < ApplicationController
+  def create
+    current_user.read_progresses.create!(text_id: params[:text_id])
+    redirect_back(fallback_location: root_path)
+  end
+
+  def destroy
+    current_user.read_progresses.find_by(text_id: params[:text_id]).destroy!
+    redirect_back(fallback_location: root_path)
+  end
+end

--- a/app/controllers/read_progresses_controller.rb
+++ b/app/controllers/read_progresses_controller.rb
@@ -1,11 +1,11 @@
 class ReadProgressesController < ApplicationController
   def create
-    current_user.read_progresses.create!(text_id: params[:text_id])
-    redirect_back(fallback_location: root_path)
+    @text = Text.find(params[:text_id])
+    current_user.read_progresses.create!(text_id: @text.id)
   end
 
   def destroy
-    current_user.read_progresses.find_by(text_id: params[:text_id]).destroy!
-    redirect_back(fallback_location: root_path)
+    @text = Text.find(params[:text_id])
+    current_user.read_progresses.find_by(text_id: @text.id).destroy!
   end
 end

--- a/app/controllers/texts_controller.rb
+++ b/app/controllers/texts_controller.rb
@@ -1,6 +1,6 @@
 class TextsController < ApplicationController
   def index
-    @texts = Text.where(genre: RAILS_GENRE_LIST)
+    @texts = Text.where(genre: RAILS_GENRE_LIST).includes(:read_progresses)
   end
 
   def show

--- a/app/models/read_progress.rb
+++ b/app/models/read_progress.rb
@@ -1,0 +1,4 @@
+class ReadProgress < ApplicationRecord
+  belongs_to :user
+  belongs_to :text
+end

--- a/app/models/read_progress.rb
+++ b/app/models/read_progress.rb
@@ -1,4 +1,8 @@
 class ReadProgress < ApplicationRecord
   belongs_to :user
   belongs_to :text
+  validates :user_id, uniqueness: {
+                        scope: :text_id,
+                        message: "は同じテキスト教材を２回以上読破済みにはできません"
+                      }
 end

--- a/app/models/text.rb
+++ b/app/models/text.rb
@@ -1,4 +1,9 @@
 class Text < ApplicationRecord
+  has_many :read_progresses, dependent: :destroy
+  def read_progressed_by?(user)
+    read_progresses.any? { |read_progress| read_progress.user_id == user.id }
+  end
+
   with_options presence: true do
     validates :genre
     validates :title

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,5 @@
 class User < ApplicationRecord
-  # Include default devise modules. Others available are:
-  # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
+  has_many :read_progresses, dependent: :destroy
   devise :database_authenticatable, :registerable,
          :rememberable, :validatable
 

--- a/app/views/read_progresses/create.js.erb
+++ b/app/views/read_progresses/create.js.erb
@@ -1,0 +1,1 @@
+document.getElementById('text-<%= @text.id %>').innerHTML = '<%= j render("texts/progress", text: @text) %>'

--- a/app/views/read_progresses/destroy.js.erb
+++ b/app/views/read_progresses/destroy.js.erb
@@ -1,0 +1,1 @@
+document.getElementById('text-<%= @text.id %>').innerHTML = '<%= j render("texts/disprogress", text: @text) %>'

--- a/app/views/texts/_disprogress.html.erb
+++ b/app/views/texts/_disprogress.html.erb
@@ -1,1 +1,1 @@
-<%= link_to "読破済みにする", text_read_progresses_path(text),class: "btn btn-block btn-secondary",method: :create %>
+<%= link_to "読破済みにする", text_read_progresses_path(text),class: "btn btn-block btn-secondary",method: :post, remote: true %>

--- a/app/views/texts/_disprogress.html.erb
+++ b/app/views/texts/_disprogress.html.erb
@@ -1,0 +1,1 @@
+<%= link_to "読破済みにする", text_read_progresses_path(text),class: "btn btn-block btn-secondary",method: :create %>

--- a/app/views/texts/_progress.html.erb
+++ b/app/views/texts/_progress.html.erb
@@ -1,0 +1,1 @@
+<%= link_to "読破済みを解除", text_read_progresses_path(text), class: 'btn btn-block btn-primary',method: :delete %>

--- a/app/views/texts/_progress.html.erb
+++ b/app/views/texts/_progress.html.erb
@@ -1,1 +1,1 @@
-<%= link_to "読破済みを解除", text_read_progresses_path(text), class: 'btn btn-block btn-primary',method: :delete %>
+<%= link_to "読破済みを解除", text_read_progresses_path(text), class: 'btn btn-block btn-primary',method: :delete, remote: true %>

--- a/app/views/texts/_text.html.erb
+++ b/app/views/texts/_text.html.erb
@@ -4,13 +4,15 @@
   <div class="card content-card border-dark mb-3">
     <%= image_tag("no_image.jpg", class: "img-fluid") %>
     <div class="card-body">
-      <% if text.read_progressed_by?(current_user) %>
-        <%= render "progress", text: text %>
-      <% else %>
-        <%= render "disprogress", text: text %>
-      <% end %>
-      <p class="card-text"><%= text.title %></p>
-      【<%= text.genre_i18n %>】
+      <p id="text-<%= text.id %>">
+        <% if text.read_progressed_by?(current_user) %>
+          <%= render "progress", text: text %>
+        <% else %>
+          <%= render "disprogress", text: text %>
+        <% end %>
+      </p>
+        <p class="card-text"><%= text.title %></p>
+        【<%= text.genre_i18n %>】
     </div>
   </div>
   <% end %>

--- a/app/views/texts/_text.html.erb
+++ b/app/views/texts/_text.html.erb
@@ -4,7 +4,11 @@
   <div class="card content-card border-dark mb-3">
     <%= image_tag("no_image.jpg", class: "img-fluid") %>
     <div class="card-body">
-      <a href="#" class="btn btn-secondary btn-block">読破済みにする</a>
+      <% if text.read_progressed_by?(current_user) %>
+        <%= render "progress", text: text %>
+      <% else %>
+        <%= render "disprogress", text: text %>
+      <% end %>
       <p class="card-text"><%= text.title %></p>
       【<%= text.genre_i18n %>】
     </div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -4,6 +4,7 @@ ja:
     models:
       text: テキスト教材
       movie: 動画教材
+      read_progress: 読破済み
     attributes:
       text:
         genre: ジャンル
@@ -13,6 +14,9 @@ ja:
         genre: ジャンル
         title: タイトル
         url: URL
+      read_progress:
+        text: テキスト教材
+        user: ユーザー
     attributes:
       id: ID
       namespace: 名前空間

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,8 @@ Rails.application.routes.draw do
     post "users/guest_sign_in", to: "users/sessions#guest_sign_in"
   end
   root "texts#index"
-  resources :texts, only: [:index, :show]
+  resources :texts, only: [:index, :show] do
+    resource :read_progresses, only: [:create, :destroy]
+  end
   resources :movies, only: [:index]
 end

--- a/db/migrate/20220327132546_create_read_progresses.rb
+++ b/db/migrate/20220327132546_create_read_progresses.rb
@@ -1,0 +1,12 @@
+class CreateReadProgresses < ActiveRecord::Migration[6.1]
+  def change
+    create_table :read_progresses do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :text, null: false, foreign_key: true
+
+      t.timestamps
+    end
+
+    add_index :read_progresses, [:user_id, :text_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_20_141914) do
+ActiveRecord::Schema.define(version: 2022_03_27_132546) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -49,6 +49,16 @@ ActiveRecord::Schema.define(version: 2022_03_20_141914) do
     t.string "url", null: false
   end
 
+  create_table "read_progresses", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "text_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["text_id"], name: "index_read_progresses_on_text_id"
+    t.index ["user_id", "text_id"], name: "index_read_progresses_on_user_id_and_text_id", unique: true
+    t.index ["user_id"], name: "index_read_progresses_on_user_id"
+  end
+
   create_table "texts", force: :cascade do |t|
     t.integer "genre", default: 0, null: false
     t.string "title", null: false
@@ -66,4 +76,6 @@ ActiveRecord::Schema.define(version: 2022_03_20_141914) do
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
+  add_foreign_key "read_progresses", "texts"
+  add_foreign_key "read_progresses", "users"
 end


### PR DESCRIPTION
close #24 

## 実装内容
- 読破済み機能に使用する`ReadProgress`モデルを作成
  - 外部キー設定を行い、ユニーク制約を入れからマイグレーション
  - バリデーションをモデルに追加
  - 関連付けを入れる
  (この時点で下記の動作確認を行いました）
- テキスト教材一覧ページに読破済み機能を実装
  - 非同期処理の実装 

## 動作確認
```
rails c -s

# Railsコンソール起動後
user = User.first
text, text2 = Text.limit(2)
ReadProgress.delete_all

user.read_progresses.create!(text_id: text.id)
user.read_progresses.create!(text_id: text2.id)

ReadProgress.count
#=> 2

text.read_progresses.create!(user_id: user.id)
#=> ActiveRecord::RecordInvalid: バリデーションに失敗しました: Userは同じテキスト教材を2回以上読破済みにはできません

ReadProgress.create!
#=> ActiveRecord::RecordInvalid: バリデーションに失敗しました: ユーザーを入力してください, テキスト教材を入力してください
```
## 参考文献
- [【やんばるエキスパート教材】モデルの関連付け その2（多対多）](https://www.yanbaru-code.com/texts/297)

## 確認事項
- テキスト教材一覧ページの読破済み機能が動作していることを確認
## チェックリスト

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行
