### PR TITLE
 動画教材のページネーションを実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,3 +36,4 @@ end
 gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 gem "enum_help"
+gem 'kaminari'

--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ gem "webpacker", "~> 5.0"
 
 group :development, :test do
   gem "byebug", platforms: [:mri, :mingw, :x64_mingw]
+  gem "kaminari"
   gem "rubocop-performance", require: false
   gem "rubocop-rails", require: false
 end
@@ -36,4 +37,3 @@ end
 gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 gem "enum_help"
-gem 'kaminari'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -285,6 +285,7 @@ DEPENDENCIES
   devise-i18n
   enum_help
   jbuilder (~> 2.7)
+  kaminari
   listen (~> 3.3)
   pg (~> 1.1)
   pre-commit

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -41,3 +41,7 @@
 a:hover {
   text-decoration: none;
 }
+
+.pagination {
+  justify-content: center;
+}

--- a/app/assets/stylesheets/movies.scss
+++ b/app/assets/stylesheets/movies.scss
@@ -1,3 +1,4 @@
 .card-title {
   height: 50px;
 }
+

--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -6,6 +6,6 @@ class MoviesController < ApplicationController
               else
                 Movie.where(genre: RAILS_GENRE_LIST)
               end
-              @movies = Movie.page(params[:page]).per(PER_PAGE)
+    @movies = @movies.page(params[:page]).per(PER_PAGE)
   end
 end

--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -1,9 +1,11 @@
 class MoviesController < ApplicationController
+  PER_PAGE = 12
   def index
     @movies = if params[:genre] == "php"
                 Movie.where(genre: PHP_GENRE_LIST)
               else
                 Movie.where(genre: RAILS_GENRE_LIST)
               end
+              @movies = Movie.page(params[:page]).per(PER_PAGE)
   end
 end

--- a/app/models/read_progress.rb
+++ b/app/models/read_progress.rb
@@ -2,7 +2,7 @@ class ReadProgress < ApplicationRecord
   belongs_to :user
   belongs_to :text
   validates :user_id, uniqueness: {
-                        scope: :text_id,
-                        message: "は同じテキスト教材を２回以上読破済みにはできません"
-                      }
+    scope: :text_id,
+    message: "は同じテキスト教材を２回以上読破済みにはできません"
+  }
 end

--- a/app/views/kaminari/_first_page.html.erb
+++ b/app/views/kaminari/_first_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_gap.html.erb
+++ b/app/views/kaminari/_gap.html.erb
@@ -1,0 +1,3 @@
+<li class='page-item disabled'>
+  <%= link_to raw(t 'views.pagination.truncate'), '#', class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_last_page.html.erb
+++ b/app/views/kaminari/_last_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, rel: 'next', remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -1,0 +1,9 @@
+<% if page.current? %>
+  <li class="page-item active">
+    <%= content_tag :a, page, data: { remote: remote }, rel: page.rel, class: 'page-link' %>
+  </li>
+<% else %>
+  <li class="page-item">
+    <%= link_to page, url, remote: remote, rel: page.rel, class: 'page-link' %>
+  </li>
+<% end %>

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -1,0 +1,19 @@
+
+    <%= paginator.render do %>
+      <nav>
+        <ul class="pagination">
+          <%= first_page_tag unless current_page.first? %>
+          <%= prev_page_tag unless current_page.first? %>
+          <% each_page do |page| %>
+            <% if page.left_outer? || page.right_outer? || page.inside_window? %>
+              <%= page_tag page %>
+            <% elsif !page.was_truncated? -%>
+              <%= gap_tag %>
+            <% end %>
+          <% end %>
+          <%= next_page_tag unless current_page.last? %>
+          <%= last_page_tag unless current_page.last? %>
+        </ul>
+      </nav>
+    <% end %>
+  

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, rel: 'prev', remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/movies/_movie.html.erb
+++ b/app/views/movies/_movie.html.erb
@@ -7,7 +7,7 @@
       <a href="#" class="btn btn-secondary btn-block">視聴済みにする</a>
       <br>
     </div>
-    <p class="card-title"><%= "Lv.#{movie_counter +1 } :" %><%= movie.title %></p>
+    <p class="card-title"><%= "Lv.#{movie_counter + @movies.offset_value + 1}:" %><%= movie.title %></p>
   </div>
 </div>
   

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -4,12 +4,9 @@
   </div>
 </div>
 
-
-
-
-
 <div class="row">
   <%= render @movies %> 
 </div>
 
+<%= paginate @movies %>
 


### PR DESCRIPTION

close #23 

## 実装内容
- 動画教材ページにページネーションを実装
  - 1ページの表示数は `12` 件

- 2ページ目以降のレベル表示を連番にする
  - `offset_value` を利用

- ページネーションに `Bootstrap` を適用

- ページネーションを中央寄せにする


## 確認内容

- Ruby/Rails動画 に ページネーション が付いていることを確認

- 動画の1ページの最大表示数が 12 であることを確認

- 2ページ目のレベル開始が `13` であることを確認

- ページネーションに Bootstrap のスタイルが適用され，中央寄せになっていることを確認
## チェックリスト

【補足】プルリクを出した後，クリックしてチェックを入れて下さい

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
- [x] `rubocop -a` を実行

